### PR TITLE
Change url to get Summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,3 @@
-<<<<<<< HEAD
 .idea/
 vendor/
-<<<<<<< HEAD
-composer.lock
-=======
->>>>>>> 09d8383ef35d34b295a950b43bec75d3891eb6a6
-=======
 composer.phar
-vendor/
-.idea/
-composer.lock
->>>>>>> 4baef86989c5dff3fc2e290230885a72a6142535

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: php
+sudo: false
+
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - nightly
+
+matrix:
+  include:
+    - php: hhvm
+      dist: trusty
+  allow_failures:
+    - php: nightly
+  fast_finish: true
+
+install:
+  - composer self-update
+  - composer install --no-interaction
+
+script:
+  - ./vendor/bin/phpcs --standard=phpcs.xml -s src

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,17 @@
 {
-   "name": "dawguk/php-garmin-connect",
-   "description": "A PHP adapter for interrogating the Garmin Connect \"API\"",
-   "require": {
-      "php": ">=5.3.0"
-   },
-   "license": "MIT",
-   "autoload": {
-      "classmap": [
-         "src/"
-      ]
-   },
-   "include-path": ["src/"]
+  "name": "dawguk/php-garmin-connect",
+  "description": "A PHP adapter for interrogating the Garmin Connect \"API\"",
+  "require": {
+    "php": ">=5.3.0"
+  },
+  "license": "MIT",
+  "autoload": {
+    "classmap": [
+      "src/"
+    ]
+  },
+  "include-path": ["src/"],
+  "require-dev": {
+    "squizlabs/php_codesniffer": "2.8.*"
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,10 +4,89 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4ee2561439655435ae23ecd5c83e75a2",
-    "content-hash": "7b9028a9a319613e1282d67736ab053c",
+    "hash": "26119c56da03fe010a92b73bb0c08946",
+    "content-hash": "afa3f9c34cde2d795c1019162b64e334",
     "packages": [],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2017-03-01 22:17:45"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,20 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "4ee2561439655435ae23ecd5c83e75a2",
+    "content-hash": "7b9028a9a319613e1282d67736ab053c",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
+}

--- a/examples/example.php
+++ b/examples/example.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 $arrCredentials = array(
    'username' => 'xxx',
@@ -9,9 +9,9 @@ $arrCredentials = array(
 try {
    $objGarminConnect = new \dawguk\GarminConnect($arrCredentials);
 
-   $objResults = $objGarminConnect->getActivityList();
+   $objResults = $objGarminConnect->getActivityList(0, 1);
    print_r($objResults);
 
 } catch (Exception $objException) {
-   echo "Oops: " . $objException->getMessage();
+   echo "Oops: " . $objException;
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--suppress XmlUnboundNsPrefix -->
+<ruleset name="PHP Garmin Connect">
+    <description>Coding standards based on the PSR-2 coding standard.</description>
+    <rule ref="PSR2"/>
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <severity>0</severity>
+    </rule>
+</ruleset>

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -84,11 +84,11 @@ class GarminConnect {
     */
    private function checkCookieAuth() {
       if (strlen(trim($this->getUsername())) == 0) {
-         $this->objConnector->cleanupSession();
-         return FALSE;
-      } else {
-         return TRUE;
+        $this->objConnector->cleanupSession();
+        $this->objConnector->refreshSession();
+        return false;
       }
+      return true;
    }
 
    /**

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -23,7 +23,6 @@ use dawguk\GarminConnect\exceptions\UnexpectedResponseCodeException;
 
 class GarminConnect
 {
-
     const DATA_TYPE_TCX = 'tcx';
     const DATA_TYPE_GPX = 'gpx';
     const DATA_TYPE_GOOGLE_EARTH = 'kml';
@@ -51,7 +50,6 @@ class GarminConnect
      */
     public function __construct(array $arrCredentials = array())
     {
-
         if (!isset($arrCredentials['username'])) {
             throw new \Exception("Username credential missing");
         }
@@ -76,7 +74,6 @@ class GarminConnect
         unset($arrCredentials['password']);
 
         $this->authorize($this->strUsername, $this->strPassword);
-
     }
 
     /**
@@ -106,7 +103,6 @@ class GarminConnect
      */
     private function authorize($strUsername, $strPassword)
     {
-
         $arrParams = array(
             'service' => 'https://connect.garmin.com/post-auth/login',
             'clientId' => 'GarminConnect',
@@ -115,8 +111,11 @@ class GarminConnect
         );
         $strResponse = $this->objConnector->get("https://sso.garmin.com/sso/login", $arrParams);
         if ($this->objConnector->getLastResponseCode() != 200) {
-            throw new AuthenticationException(sprintf("SSO prestart error (code: %d, message: %s)",
-                $this->objConnector->getLastResponseCode(), $strResponse));
+            throw new AuthenticationException(sprintf(
+                "SSO prestart error (code: %d, message: %s)",
+                $this->objConnector->getLastResponseCode(),
+                $strResponse
+            ));
         }
 
         $arrData = array(
@@ -131,7 +130,6 @@ class GarminConnect
         preg_match("/ticket=([^\"]+)\"/", $strResponse, $arrMatches);
 
         if (!isset($arrMatches[1])) {
-
             $strMessage = "Authentication failed - please check your credentials";
 
             preg_match("/locked/", $strResponse, $arrLocked);
@@ -164,7 +162,6 @@ class GarminConnect
 
         // Fires up a fresh CuRL instance, because of our reliance on Cookies requiring "a new page load" as it were ...
         $this->objConnector->refreshSession();
-
     }
 
     /**
@@ -173,8 +170,12 @@ class GarminConnect
      */
     public function getActivityTypes()
     {
-        $strResponse = $this->objConnector->get('https://connect.garmin.com/proxy/activity-service-1.2/json/activity_types',
-            null, null, false);
+        $strResponse = $this->objConnector->get(
+            'https://connect.garmin.com/proxy/activity-service-1.2/json/activity_types',
+            null,
+            null,
+            false
+        );
         if ($this->objConnector->getLastResponseCode() != 200) {
             throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
         }
@@ -192,14 +193,16 @@ class GarminConnect
      */
     public function getActivityList($intStart = 0, $intLimit = 10)
     {
-
         $arrParams = array(
             'start' => $intStart,
             'limit' => $intLimit
         );
 
-        $strResponse = $this->objConnector->get('https://connect.garmin.com/proxy/activity-search-service-1.0/json/activities',
-            $arrParams, true);
+        $strResponse = $this->objConnector->get(
+            'https://connect.garmin.com/proxy/activity-search-service-1.0/json/activities',
+            $arrParams,
+            true
+        );
         if ($this->objConnector->getLastResponseCode() != 200) {
             throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
         }
@@ -264,9 +267,7 @@ class GarminConnect
      */
     public function getDataFile($strType, $intActivityID)
     {
-
         switch ($strType) {
-
             case self::DATA_TYPE_GPX:
             case self::DATA_TYPE_TCX:
             case self::DATA_TYPE_GOOGLE_EARTH:
@@ -274,7 +275,6 @@ class GarminConnect
 
             default:
                 throw new \Exception("Unsupported data type");
-
         }
 
         $strUrl = "https://connect.garmin.com/proxy/download-service/export/" . $strType . "/activity/" . $intActivityID;
@@ -299,5 +299,4 @@ class GarminConnect
         $objResponse = json_decode($strResponse);
         return $objResponse->username;
     }
-
 }

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -104,9 +104,10 @@ class GarminConnect {
    private function authorize($strUsername, $strPassword) {
 
       $arrParams = array(
-         'service' => "https://connect.garmin.com/post-auth/login",
+         'service' => 'https://connect.garmin.com/post-auth/login',
          'clientId' => 'GarminConnect',
-         'consumeServiceTicket' => "false"
+         'gauthHost' => 'https://sso.garmin.com/sso',
+         'consumeServiceTicket' => 'false'
       );
       $strResponse = $this->objConnector->get("https://sso.garmin.com/sso/login", $arrParams);
       if ($this->objConnector->getLastResponseCode() != 200) {

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -133,6 +133,7 @@ class GarminConnect {
       preg_match("/ticket=([^']+)'/", $strResponse, $arrMatches);
 
       if (!isset($arrMatches[1])) {
+         $this->objConnector->clearCookie();
          throw new AuthenticationException("Ticket value wasn't found in response - looks like the authentication failed.");
       }
 

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -284,7 +284,9 @@ class GarminConnect
 
         }
 
-        $strResponse = $this->objConnector->get("https://connect.garmin.com/proxy/activity-service-1.2/" . $strType . "/activity/" . $intActivityID . "?full=true");
+        $strUrl = "https://connect.garmin.com/proxy/download-service/export/" . $strType . "/activity/" . $intActivityID;
+
+        $strResponse = $this->objConnector->get($strUrl);
         if ($this->objConnector->getLastResponseCode() != 200) {
             throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
         }

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -127,15 +127,8 @@ class GarminConnect
             "displayNameRequired" => "false"
         );
 
-        preg_match("/name=\"lt\"\s+value=\"([^\"]+)\"/", $strResponse, $arrMatches);
-        if (!isset($arrMatches[1])) {
-            throw new AuthenticationException("\"lt\" value wasn't found in response");
-        }
-
-        $arrData['lt'] = $arrMatches[1];
-
         $strResponse = $this->objConnector->post("https://sso.garmin.com/sso/login", $arrParams, $arrData, false);
-        preg_match("/ticket=([^']+)'/", $strResponse, $arrMatches);
+        preg_match("/ticket=([^\"]+)\"/", $strResponse, $arrMatches);
 
         if (!isset($arrMatches[1])) {
 

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -80,12 +80,11 @@ class GarminConnect {
    /**
     * Try to read the username from the API - if successful, it means we have a valid cookie, and we don't need to auth
     *
-    * @internal param $strUsername
     * @return bool
     */
    private function checkCookieAuth() {
       if (strlen(trim($this->getUsername())) == 0) {
-         $this->objConnector->clearCookie();
+         $this->objConnector->cleanupSession();
          return FALSE;
       } else {
          return TRUE;
@@ -133,8 +132,15 @@ class GarminConnect {
       preg_match("/ticket=([^']+)'/", $strResponse, $arrMatches);
 
       if (!isset($arrMatches[1])) {
-         $this->objConnector->clearCookie();
-         throw new AuthenticationException("Ticket value wasn't found in response - looks like the authentication failed.");
+
+         $strMessage = "Looks like the authentication failed";
+
+         preg_match("/locked/", $strResponse, $arrLocked);
+         if ($arrLocked[0]) {
+            $strMessage = "Looks like your account has been locked. Please access https://connect.garmin.com";
+         }
+         $this->objConnector->cleanupSession();
+         throw new AuthenticationException($strMessage);
       }
 
       $strTicket = $arrMatches[1];

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -21,272 +21,288 @@ use dawguk\GarminConnect\Connector;
 use dawguk\GarminConnect\exceptions\AuthenticationException;
 use dawguk\GarminConnect\exceptions\UnexpectedResponseCodeException;
 
-class GarminConnect {
+class GarminConnect
+{
 
-   const DATA_TYPE_TCX = 'tcx';
-   const DATA_TYPE_GPX = 'gpx';
-   const DATA_TYPE_GOOGLE_EARTH = 'kml';
+    const DATA_TYPE_TCX = 'tcx';
+    const DATA_TYPE_GPX = 'gpx';
+    const DATA_TYPE_GOOGLE_EARTH = 'kml';
 
-   /**
-    * @var string
-    */
-   private $strUsername = '';
+    /**
+     * @var string
+     */
+    private $strUsername = '';
 
-   /**
-    * @var string
-    */
-   private $strPassword = '';
+    /**
+     * @var string
+     */
+    private $strPassword = '';
 
-   /**
-    * @var GarminConnect\Connector|null
-    */
-   private $objConnector = NULL;
+    /**
+     * @var GarminConnect\Connector|null
+     */
+    private $objConnector = null;
 
-   /**
-    * Performs some essential setup
-    *
-    * @param array $arrCredentials
-    * @throws \Exception
-    */
-   public function __construct(array $arrCredentials = array()) {
+    /**
+     * Performs some essential setup
+     *
+     * @param array $arrCredentials
+     * @throws \Exception
+     */
+    public function __construct(array $arrCredentials = array())
+    {
 
-      if (!isset($arrCredentials['username'])) {
-         throw new \Exception("Username credential missing");
-      }
+        if (!isset($arrCredentials['username'])) {
+            throw new \Exception("Username credential missing");
+        }
 
-      $this->strUsername = $arrCredentials['username'];
-      unset($arrCredentials['username']);
+        $this->strUsername = $arrCredentials['username'];
+        unset($arrCredentials['username']);
 
-      $intIdentifier = md5($this->strUsername);
+        $intIdentifier = md5($this->strUsername);
 
-      $this->objConnector = new Connector($intIdentifier);
+        $this->objConnector = new Connector($intIdentifier);
 
-      // If we can validate the cached auth, we don't need to do anything else
-      if ($this->checkCookieAuth()) {
-         return;
-      }
+        // If we can validate the cached auth, we don't need to do anything else
+        if ($this->checkCookieAuth()) {
+            return;
+        }
 
-      if (!isset($arrCredentials['password'])){
-         throw new \Exception("Password credential missing");
-      }
+        if (!isset($arrCredentials['password'])) {
+            throw new \Exception("Password credential missing");
+        }
 
-      $this->strPassword = $arrCredentials['password'];
-      unset($arrCredentials['password']);
+        $this->strPassword = $arrCredentials['password'];
+        unset($arrCredentials['password']);
 
-      $this->authorize($this->strUsername, $this->strPassword);
+        $this->authorize($this->strUsername, $this->strPassword);
 
-   }
+    }
 
-   /**
-    * Try to read the username from the API - if successful, it means we have a valid cookie, and we don't need to auth
-    *
-    * @return bool
-    */
-   private function checkCookieAuth() {
-      if (strlen(trim($this->getUsername())) == 0) {
-        $this->objConnector->cleanupSession();
+    /**
+     * Try to read the username from the API - if successful, it means we have a valid cookie, and we don't need to auth
+     *
+     * @return bool
+     */
+    private function checkCookieAuth()
+    {
+        if (strlen(trim($this->getUsername())) == 0) {
+            $this->objConnector->cleanupSession();
+            $this->objConnector->refreshSession();
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Because there doesn't appear to be a nice "API" way to authenticate with Garmin Connect, we have to effectively spoof
+     * a browser session using some pretty high-level scraping techniques. The connector object does all of the HTTP
+     * work, and is effectively a wrapper for CURL-based session handler (via CURLs in-built cookie storage).
+     *
+     * @param string $strUsername
+     * @param string $strPassword
+     * @throws AuthenticationException
+     * @throws UnexpectedResponseCodeException
+     */
+    private function authorize($strUsername, $strPassword)
+    {
+
+        $arrParams = array(
+            'service' => 'https://connect.garmin.com/post-auth/login',
+            'clientId' => 'GarminConnect',
+            'gauthHost' => 'https://sso.garmin.com/sso',
+            'consumeServiceTicket' => 'false'
+        );
+        $strResponse = $this->objConnector->get("https://sso.garmin.com/sso/login", $arrParams);
+        if ($this->objConnector->getLastResponseCode() != 200) {
+            throw new AuthenticationException(sprintf("SSO prestart error (code: %d, message: %s)",
+                $this->objConnector->getLastResponseCode(), $strResponse));
+        }
+
+        $arrData = array(
+            "username" => $strUsername,
+            "password" => $strPassword,
+            "_eventId" => "submit",
+            "embed" => "true",
+            "displayNameRequired" => "false"
+        );
+
+        preg_match("/name=\"lt\"\s+value=\"([^\"]+)\"/", $strResponse, $arrMatches);
+        if (!isset($arrMatches[1])) {
+            throw new AuthenticationException("\"lt\" value wasn't found in response");
+        }
+
+        $arrData['lt'] = $arrMatches[1];
+
+        $strResponse = $this->objConnector->post("https://sso.garmin.com/sso/login", $arrParams, $arrData, false);
+        preg_match("/ticket=([^']+)'/", $strResponse, $arrMatches);
+
+        if (!isset($arrMatches[1])) {
+
+            $strMessage = "Authentication failed - please check your credentials";
+
+            preg_match("/locked/", $strResponse, $arrLocked);
+
+            if (isset($arrLocked[0])) {
+                $strMessage = "Authentication failed, and it looks like your account has been locked. Please access https://connect.garmin.com to unlock";
+            }
+
+            $this->objConnector->cleanupSession();
+            throw new AuthenticationException($strMessage);
+        }
+
+        $strTicket = $arrMatches[1];
+        $arrParams = array(
+            'ticket' => $strTicket
+        );
+
+        $this->objConnector->post('https://connect.garmin.com/post-auth/login', $arrParams, null, false);
+        if ($this->objConnector->getLastResponseCode() != 302) {
+            throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
+        }
+
+        // should only exist if the above response WAS a 302 ;)
+        $strRedirectUrl = $this->objConnector->getCurlInfo()['redirect_url'];
+
+        $this->objConnector->get($strRedirectUrl, null, null, true);
+        if ($this->objConnector->getLastResponseCode() != 302) {
+            throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
+        }
+
+        // Fires up a fresh CuRL instance, because of our reliance on Cookies requiring "a new page load" as it were ...
         $this->objConnector->refreshSession();
-        return false;
-      }
-      return true;
-   }
 
-   /**
-    * Because there doesn't appear to be a nice "API" way to authenticate with Garmin Connect, we have to effectively spoof
-    * a browser session using some pretty high-level scraping techniques. The connector object does all of the HTTP
-    * work, and is effectively a wrapper for CURL-based session handler (via CURLs in-built cookie storage).
-    *
-    * @param string $strUsername
-    * @param string $strPassword
-    * @throws AuthenticationException
-    * @throws UnexpectedResponseCodeException
-    */
-   private function authorize($strUsername, $strPassword) {
+    }
 
-      $arrParams = array(
-         'service' => 'https://connect.garmin.com/post-auth/login',
-         'clientId' => 'GarminConnect',
-         'gauthHost' => 'https://sso.garmin.com/sso',
-         'consumeServiceTicket' => 'false'
-      );
-      $strResponse = $this->objConnector->get("https://sso.garmin.com/sso/login", $arrParams);
-      if ($this->objConnector->getLastResponseCode() != 200) {
-         throw new AuthenticationException(sprintf("SSO prestart error (code: %d, message: %s)", $this->objConnector->getLastResponseCode() , $strResponse));
-      }
+    /**
+     * @return mixed
+     * @throws UnexpectedResponseCodeException
+     */
+    public function getActivityTypes()
+    {
+        $strResponse = $this->objConnector->get('https://connect.garmin.com/proxy/activity-service-1.2/json/activity_types',
+            null, null, false);
+        if ($this->objConnector->getLastResponseCode() != 200) {
+            throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
+        }
+        $objResponse = json_decode($strResponse);
+        return $objResponse;
+    }
 
-      $arrData = array(
-         "username" => $strUsername,
-         "password" => $strPassword,
-         "_eventId" => "submit",
-         "embed" => "true",
-         "displayNameRequired" => "false"
-      );
+    /**
+     * Gets a list of activities
+     *
+     * @param integer $intStart
+     * @param integer $intLimit
+     * @throws UnexpectedResponseCodeException
+     * @return mixed
+     */
+    public function getActivityList($intStart = 0, $intLimit = 10)
+    {
 
-      preg_match("/name=\"lt\"\s+value=\"([^\"]+)\"/", $strResponse, $arrMatches);
-      if (!isset($arrMatches[1])) {
-         throw new AuthenticationException("\"lt\" value wasn't found in response");
-      }
+        $arrParams = array(
+            'start' => $intStart,
+            'limit' => $intLimit
+        );
 
-      $arrData['lt'] = $arrMatches[1];
+        $strResponse = $this->objConnector->get('https://connect.garmin.com/proxy/activity-search-service-1.0/json/activities',
+            $arrParams, true);
+        if ($this->objConnector->getLastResponseCode() != 200) {
+            throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
+        }
+        $objResponse = json_decode($strResponse);
+        return $objResponse;
+    }
 
-      $strResponse = $this->objConnector->post("https://sso.garmin.com/sso/login", $arrParams, $arrData, FALSE);
-      preg_match("/ticket=([^']+)'/", $strResponse, $arrMatches);
+    /**
+     * Gets the summary information for the activity
+     *
+     * @param integer $intActivityID
+     * @return mixed
+     * @throws GarminConnect\exceptions\UnexpectedResponseCodeException
+     */
+    public function getActivitySummary($intActivityID)
+    {
+        $strResponse = $this->objConnector->get("https://connect.garmin.com/proxy/activity-service-1.3/json/activity/" . $intActivityID);
+        if ($this->objConnector->getLastResponseCode() != 200) {
+            throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
+        }
+        $objResponse = json_decode($strResponse);
+        return $objResponse;
+    }
 
-      if (!isset($arrMatches[1])) {
+    /**
+     * Gets the detailed information for the activity
+     *
+     * @param integer $intActivityID
+     * @return mixed
+     * @throws GarminConnect\exceptions\UnexpectedResponseCodeException
+     */
+    public function getActivityDetails($intActivityID)
+    {
+        $strResponse = $this->objConnector->get("https://connect.garmin.com/proxy/activity-service-1.3/json/activityDetails/" . $intActivityID);
+        if ($this->objConnector->getLastResponseCode() != 200) {
+            throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
+        }
+        $objResponse = json_decode($strResponse);
+        return $objResponse;
+    }
 
-         $strMessage = "Looks like the authentication failed";
+    /**
+     * Gets the extended details for the activity
+     *
+     * @param $intActivityID
+     * @return mixed
+     */
+    public function getExtendedActivityDetails($intActivityID)
+    {
+        $strResponse = $this->objConnector->get("https://connect.garmin.com/modern/proxy/activity-service/activity/" . $intActivityID . "/details?maxChartSize=1000&maxPolylineSize=1000");
+        return json_decode($strResponse);
+    }
 
-         preg_match("/locked/", $strResponse, $arrLocked);
-         if ($arrLocked[0]) {
-            $strMessage = "Looks like your account has been locked. Please access https://connect.garmin.com";
-         }
-         $this->objConnector->cleanupSession();
-         throw new AuthenticationException($strMessage);
-      }
+    /**
+     * Retrieves the data file for the activity
+     *
+     * @param string $strType
+     * @param $intActivityID
+     * @throws GarminConnect\exceptions\UnexpectedResponseCodeException
+     * @throws \Exception
+     * @return mixed
+     */
+    public function getDataFile($strType, $intActivityID)
+    {
 
-      $strTicket = $arrMatches[1];
-      $arrParams = array(
-         'ticket' => $strTicket
-      );
+        switch ($strType) {
 
-      $this->objConnector->post('https://connect.garmin.com/post-auth/login', $arrParams, null, FALSE);
-      if ($this->objConnector->getLastResponseCode() != 302) {
-         throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
-      }
+            case self::DATA_TYPE_GPX:
+            case self::DATA_TYPE_TCX:
+            case self::DATA_TYPE_GOOGLE_EARTH:
+                break;
 
-      // should only exist if the above response WAS a 302 ;)
-      $strRedirectUrl = $this->objConnector->getCurlInfo()['redirect_url'];
+            default:
+                throw new \Exception("Unsupported data type");
 
-      $this->objConnector->get($strRedirectUrl, null, null, TRUE);
-      if ($this->objConnector->getLastResponseCode() != 302) {
-         throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
-      }
+        }
 
-      // Fires up a fresh CuRL instance, because of our reliance on Cookies requiring "a new page load" as it were ...
-      $this->objConnector->refreshSession();
+        $strResponse = $this->objConnector->get("https://connect.garmin.com/proxy/activity-service-1.2/" . $strType . "/activity/" . $intActivityID . "?full=true");
+        if ($this->objConnector->getLastResponseCode() != 200) {
+            throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
+        }
+        return $strResponse;
+    }
 
-   }
-
-   /**
-    * @return mixed
-    * @throws UnexpectedResponseCodeException
-    */
-   public function getActivityTypes() {
-      $strResponse = $this->objConnector->get('https://connect.garmin.com/proxy/activity-service-1.2/json/activity_types', null, null, FALSE);
-      if ($this->objConnector->getLastResponseCode() != 200) {
-         throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
-      }
-      $objResponse = json_decode($strResponse);
-      return $objResponse;
-   }
-
-   /**
-    * Gets a list of activities
-    *
-    * @param integer $intStart
-    * @param integer $intLimit
-    * @throws UnexpectedResponseCodeException
-    * @return mixed
-    */
-   public function getActivityList($intStart = 0, $intLimit = 10) {
-
-      $arrParams = array(
-         'start' => $intStart,
-         'limit' => $intLimit
-      );
-
-      $strResponse = $this->objConnector->get('https://connect.garmin.com/proxy/activity-search-service-1.0/json/activities', $arrParams, TRUE);
-      if ($this->objConnector->getLastResponseCode() != 200) {
-         throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
-      }
-      $objResponse = json_decode($strResponse);
-      return $objResponse;
-   }
-
-   /**
-    * Gets the summary information for the activity
-    *
-    * @param integer $intActivityID
-    * @return mixed
-    * @throws GarminConnect\exceptions\UnexpectedResponseCodeException
-    */
-   public function getActivitySummary($intActivityID) {
-      $strResponse = $this->objConnector->get("https://connect.garmin.com/proxy/activity-service-1.3/json/activity/" . $intActivityID);
-      if ($this->objConnector->getLastResponseCode() != 200) {
-         throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
-      }
-      $objResponse = json_decode($strResponse);
-      return $objResponse;
-   }
-
-   /**
-    * Gets the detailed information for the activity
-    *
-    * @param integer $intActivityID
-    * @return mixed
-    * @throws GarminConnect\exceptions\UnexpectedResponseCodeException
-    */
-   public function getActivityDetails($intActivityID) {
-      $strResponse = $this->objConnector->get("https://connect.garmin.com/proxy/activity-service-1.3/json/activityDetails/" . $intActivityID);
-      if ($this->objConnector->getLastResponseCode() != 200) {
-         throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
-      }
-      $objResponse = json_decode($strResponse);
-      return $objResponse;
-   }
-
-   /**
-    * Gets the extended details for the activity
-    *
-    * @param $intActivityID
-    * @return mixed
-    */
-   public function getExtendedActivityDetails($intActivityID) {
-      $strResponse = $this->objConnector->get("https://connect.garmin.com/modern/proxy/activity-service/activity/" . $intActivityID . "/details?maxChartSize=1000&maxPolylineSize=1000");
-      return json_decode($strResponse);
-   }
-
-   /**
-    * Retrieves the data file for the activity
-    *
-    * @param string $strType
-    * @param $intActivityID
-    * @throws GarminConnect\exceptions\UnexpectedResponseCodeException
-    * @throws \Exception
-    * @return mixed
-    */
-   public function getDataFile($strType, $intActivityID) {
-
-      switch ($strType) {
-
-         case self::DATA_TYPE_GPX:
-         case self::DATA_TYPE_TCX:
-         case self::DATA_TYPE_GOOGLE_EARTH:
-            break;
-
-         default:
-            throw new \Exception("Unsupported data type");
-
-      }
-
-      $strResponse = $this->objConnector->get("https://connect.garmin.com/proxy/activity-service-1.2/" . $strType . "/activity/" . $intActivityID . "?full=true");
-      if ($this->objConnector->getLastResponseCode() != 200) {
-         throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
-      }
-      return $strResponse;
-   }
-
-   /**
-    * @return mixed
-    * @throws UnexpectedResponseCodeException
-    */
-   public function getUsername() {
-      $strResponse = $this->objConnector->get('https://connect.garmin.com/user/username');
-      if ($this->objConnector->getLastResponseCode() != 200) {
-         throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
-      }
-      $objResponse = json_decode($strResponse);
-      return $objResponse->username;
-   }
+    /**
+     * @return mixed
+     * @throws UnexpectedResponseCodeException
+     */
+    public function getUsername()
+    {
+        $strResponse = $this->objConnector->get('https://connect.garmin.com/user/username');
+        if ($this->objConnector->getLastResponseCode() != 200) {
+            throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
+        }
+        $objResponse = json_decode($strResponse);
+        return $objResponse->username;
+    }
 
 }

--- a/src/dawguk/GarminConnect/Connector.php
+++ b/src/dawguk/GarminConnect/Connector.php
@@ -144,4 +144,12 @@ class Connector {
       }
    }
 
+   /**
+    * Closes curl and then clears the cookie.
+    */
+   public function cleanupSession() {
+      curl_close($this->objCurl);
+      $this->clearCookie();
+   }
+
 } 

--- a/src/dawguk/GarminConnect/Connector.php
+++ b/src/dawguk/GarminConnect/Connector.php
@@ -9,7 +9,7 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- * 
+ *
  * @author David Wilcock <dave.wilcock@gmail.com>
  * @copyright David Wilcock &copy; 2014
  * @package
@@ -17,60 +17,62 @@
 
 namespace dawguk\GarminConnect;
 
-class Connector {
-
+class Connector
+{
    /**
     * @var null|resource
     */
-   private $objCurl = NULL;
-   private $arrCurlInfo = array();
-   private $strCookieDirectory = '';
+    private $objCurl = null;
+    private $arrCurlInfo = array();
+    private $strCookieDirectory = '';
 
    /**
     * @var array
     */
-   private $arrCurlOptions = array(
-      CURLOPT_RETURNTRANSFER => TRUE,
-      CURLOPT_SSL_VERIFYHOST => FALSE,
-      CURLOPT_SSL_VERIFYPEER => FALSE,
-      CURLOPT_COOKIESESSION => FALSE,
-      CURLOPT_AUTOREFERER => TRUE,
-      CURLOPT_VERBOSE => FALSE,
-      CURLOPT_FRESH_CONNECT => TRUE
-   );
+    private $arrCurlOptions = array(
+      CURLOPT_RETURNTRANSFER => true,
+      CURLOPT_SSL_VERIFYHOST => false,
+      CURLOPT_SSL_VERIFYPEER => false,
+      CURLOPT_COOKIESESSION => false,
+      CURLOPT_AUTOREFERER => true,
+      CURLOPT_VERBOSE => false,
+      CURLOPT_FRESH_CONNECT => true
+    );
 
    /**
     * @var int
     */
-   private $intLastResponseCode = -1;
+    private $intLastResponseCode = -1;
 
    /**
     * @var string
     */
-   private $strCookieFile = '';
+    private $strCookieFile = '';
 
    /**
     * @param string $strUniqueIdentifier
     * @throws \Exception
     */
-   public function __construct($strUniqueIdentifier) {
-      $this->strCookieDirectory = sys_get_temp_dir();
-      if (strlen(trim($strUniqueIdentifier)) == 0) {
-         throw new \Exception("Identifier isn't valid");
-      }
-      $this->strCookieFile = $this->strCookieDirectory . DIRECTORY_SEPARATOR . "GarminCookie_" . $strUniqueIdentifier;
-      $this->refreshSession();
-   }
+    public function __construct($strUniqueIdentifier)
+    {
+        $this->strCookieDirectory = sys_get_temp_dir();
+        if (strlen(trim($strUniqueIdentifier)) == 0) {
+            throw new \Exception("Identifier isn't valid");
+        }
+        $this->strCookieFile = $this->strCookieDirectory . DIRECTORY_SEPARATOR . "GarminCookie_" . $strUniqueIdentifier;
+        $this->refreshSession();
+    }
 
    /**
     * Create a new curl instance
     */
-   public function refreshSession() {
-      $this->objCurl = curl_init();
-      $this->arrCurlOptions[CURLOPT_COOKIEJAR] = $this->strCookieFile;
-      $this->arrCurlOptions[CURLOPT_COOKIEFILE] = $this->strCookieFile;
-      curl_setopt_array($this->objCurl, $this->arrCurlOptions);
-   }
+    public function refreshSession()
+    {
+        $this->objCurl = curl_init();
+        $this->arrCurlOptions[CURLOPT_COOKIEJAR] = $this->strCookieFile;
+        $this->arrCurlOptions[CURLOPT_COOKIEFILE] = $this->strCookieFile;
+        curl_setopt_array($this->objCurl, $this->arrCurlOptions);
+    }
 
    /**
     * @param string $strUrl
@@ -78,20 +80,21 @@ class Connector {
     * @param bool $bolAllowRedirects
     * @return mixed
     */
-   public function get($strUrl, $arrParams = array(), $bolAllowRedirects = TRUE) {
-      if (count($arrParams)) {
-         $strUrl .= '?' . http_build_query($arrParams);
-      }
+    public function get($strUrl, $arrParams = array(), $bolAllowRedirects = true)
+    {
+        if (count($arrParams)) {
+            $strUrl .= '?' . http_build_query($arrParams);
+        }
 
-      curl_setopt($this->objCurl, CURLOPT_URL, $strUrl);
-      curl_setopt($this->objCurl, CURLOPT_FOLLOWLOCATION, (bool)$bolAllowRedirects);
-      curl_setopt($this->objCurl, CURLOPT_CUSTOMREQUEST, 'GET');
+        curl_setopt($this->objCurl, CURLOPT_URL, $strUrl);
+        curl_setopt($this->objCurl, CURLOPT_FOLLOWLOCATION, (bool)$bolAllowRedirects);
+        curl_setopt($this->objCurl, CURLOPT_CUSTOMREQUEST, 'GET');
 
-      $strResponse = curl_exec($this->objCurl);
-      $arrCurlInfo = curl_getinfo($this->objCurl);
-      $this->intLastResponseCode = $arrCurlInfo['http_code'];
-      return $strResponse;
-   }
+        $strResponse = curl_exec($this->objCurl);
+        $arrCurlInfo = curl_getinfo($this->objCurl);
+        $this->intLastResponseCode = $arrCurlInfo['http_code'];
+        return $strResponse;
+    }
 
    /**
     * @param string $strUrl
@@ -100,56 +103,60 @@ class Connector {
     * @param bool $bolAllowRedirects
     * @return mixed
     */
-   public function post($strUrl, $arrParams = array(), $arrData = array(), $bolAllowRedirects = TRUE) {
+    public function post($strUrl, $arrParams = array(), $arrData = array(), $bolAllowRedirects = true)
+    {
 
-      curl_setopt($this->objCurl, CURLOPT_HEADER, TRUE);
-      curl_setopt($this->objCurl, CURLOPT_FRESH_CONNECT, TRUE);
-      curl_setopt($this->objCurl, CURLOPT_FOLLOWLOCATION, (bool)$bolAllowRedirects);
-      curl_setopt($this->objCurl, CURLOPT_CUSTOMREQUEST, "POST");
-      curl_setopt($this->objCurl, CURLOPT_VERBOSE, FALSE);
-      if (count($arrData)) {
-         curl_setopt($this->objCurl, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded'));
-         curl_setopt($this->objCurl, CURLOPT_POSTFIELDS, http_build_query($arrData));
-      }
-      $strUrl .= '?' . http_build_query($arrParams);
+        curl_setopt($this->objCurl, CURLOPT_HEADER, true);
+        curl_setopt($this->objCurl, CURLOPT_FRESH_CONNECT, true);
+        curl_setopt($this->objCurl, CURLOPT_FOLLOWLOCATION, (bool)$bolAllowRedirects);
+        curl_setopt($this->objCurl, CURLOPT_CUSTOMREQUEST, "POST");
+        curl_setopt($this->objCurl, CURLOPT_VERBOSE, false);
+        if (count($arrData)) {
+            curl_setopt($this->objCurl, CURLOPT_HTTPHEADER, array('Content-Type: application/x-www-form-urlencoded'));
+            curl_setopt($this->objCurl, CURLOPT_POSTFIELDS, http_build_query($arrData));
+        }
+        $strUrl .= '?' . http_build_query($arrParams);
 
-      curl_setopt($this->objCurl, CURLOPT_URL, $strUrl);
+        curl_setopt($this->objCurl, CURLOPT_URL, $strUrl);
 
-      $strResponse = curl_exec($this->objCurl);
-      $this->arrCurlInfo = curl_getinfo($this->objCurl);
-      $this->intLastResponseCode = (int)$this->arrCurlInfo['http_code'];
-      return $strResponse;
-   }
+        $strResponse = curl_exec($this->objCurl);
+        $this->arrCurlInfo = curl_getinfo($this->objCurl);
+        $this->intLastResponseCode = (int)$this->arrCurlInfo['http_code'];
+        return $strResponse;
+    }
 
    /**
     * @return array
     */
-   public function getCurlInfo() {
-      return $this->arrCurlInfo;
-   }
+    public function getCurlInfo()
+    {
+        return $this->arrCurlInfo;
+    }
 
    /**
     * @return int
     */
-   public function getLastResponseCode() {
-      return $this->intLastResponseCode;
-   }
+    public function getLastResponseCode()
+    {
+        return $this->intLastResponseCode;
+    }
 
    /**
     * Removes the cookie
     */
-   public function clearCookie() {
-      if (file_exists($this->strCookieFile)) {
-         unlink($this->strCookieFile);
-      }
-   }
+    public function clearCookie()
+    {
+        if (file_exists($this->strCookieFile)) {
+            unlink($this->strCookieFile);
+        }
+    }
 
    /**
     * Closes curl and then clears the cookie.
     */
-   public function cleanupSession() {
-      curl_close($this->objCurl);
-      $this->clearCookie();
-   }
-
-} 
+    public function cleanupSession()
+    {
+        curl_close($this->objCurl);
+        $this->clearCookie();
+    }
+}

--- a/src/dawguk/GarminConnect/exceptions/AuthenticationException.php
+++ b/src/dawguk/GarminConnect/exceptions/AuthenticationException.php
@@ -17,6 +17,7 @@
 
 namespace dawguk\GarminConnect\exceptions;
 
-class AuthenticationException extends \Exception {
+class AuthenticationException extends \Exception
+{
 
-} 
+}

--- a/src/dawguk/GarminConnect/exceptions/RedirectException.php
+++ b/src/dawguk/GarminConnect/exceptions/RedirectException.php
@@ -17,6 +17,7 @@
 
 namespace dawguk\GarminConnect\exceptions;
 
-class RedirectException extends \Exception {
+class RedirectException extends \Exception
+{
 
-} 
+}

--- a/src/dawguk/GarminConnect/exceptions/UnexpectedResponseCodeException.php
+++ b/src/dawguk/GarminConnect/exceptions/UnexpectedResponseCodeException.php
@@ -16,12 +16,11 @@
  */
 namespace dawguk\GarminConnect\exceptions;
 
-
-class UnexpectedResponseCodeException extends \Exception {
-
-   public function __construct($strResponseCode){
-      $strMessage = "An unexpected response code was found: " . $strResponseCode;
-      parent::__construct($strMessage, 0, null);
-   }
-
-} 
+class UnexpectedResponseCodeException extends \Exception
+{
+    public function __construct($strResponseCode)
+    {
+        $strMessage = "An unexpected response code was found: " . $strResponseCode;
+        parent::__construct($strMessage, 0, null);
+    }
+}


### PR DESCRIPTION
You could find the new url to match with Garmin.

`    public function getActivitySummary($intActivityID)
    {
        //$strResponse = $this->objConnector->get("https://connect.garmin.com/proxy/activity-service-1.3/json/activity/" . $intActivityID);
       $strResponse = $this->objConnector->get("https://connect.garmin.com/modern/proxy/activity-service/activity/" . $intActivityID);
        
        if ($this->objConnector->getLastResponseCode() != 200) {
            throw new UnexpectedResponseCodeException($this->objConnector->getLastResponseCode());
        }
        $objResponse = json_decode($strResponse);
        return $objResponse;
    }`

