### PR TITLE
Activity Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `getActivityTypes()` had it's endpoint URL fixed, so is now working again.
+
+### Added
+
+- Can now call `getActivityList()` with an optional third parameter, which is a string representation of the activity type
+that is returned in the `getActivityTypes()` method. README and example updated, please check for instructions.
+
 ## [v1.1.2] - 2019-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $arrCredentials = array(
 try {
    $objGarminConnect = new \dawguk\GarminConnect($arrCredentials);
 
-   $objResults = $objGarminConnect->getActivityList(0, 1);
+   $objResults = $objGarminConnect->getActivityList(0, 1, 'cycling');
    foreach($objResults->results->activities as $objActivity) {
       print_r($objActivity->activity);
    }
@@ -49,8 +49,8 @@ The library implements a few basic API functions that you can use to retrieve us
 
 | Method                  | Parameters           | Returns                     |
 | ----------------------- | -------------------- | --------------------------- |
-| getActivityTypes()      | -                 | stdClass                    |
-| getActivityList()       | integer $intStart, integer $intLimit | stdClass    |
+| getActivityTypes()      | -                 | Array                    |
+| getActivityList()       | integer $intStart, integer $intLimit, string $strActivityType | stdClass    |
 | getActivitySummary()    | integer $intActivityID | stdClass                  |
 | getActivityDetails()    | integer $intActivityID | stdClass |
 | getDataFile             | string $strType, integer $intActivityID | string |
@@ -77,27 +77,28 @@ try {
 
 #### Response
 
-    stdClass Object
+    Array
     (
-    [key] => road_biking
-    [display] => Road Cycling
-    [parent] => stdClass Object
-        (
-            [key] => cycling
-            [display] => Cycling
-        )
+        [0] => stdClass Object
+            (
+                [typeId] => 1
+                [typeKey] => running
+                [parentTypeId] => 17
+                [sortOrder] => 3
+            )
+    
+        [1] => stdClass Object
+            (
+                [typeId] => 2
+                [typeKey] => cycling
+                [parentTypeId] => 17
+                [sortOrder] => 8
+            )
 
-    [type] => stdClass Object
-        (
-            [key] => cycling
-            [display] => Cycling
-        )
-
-    )
  
-### getActivityList(integer $intStart, integer $intLimit)
+### getActivityList(integer $intStart, integer $intLimit, string $strActivityType)
 
-Returns a stdClass object, which contains an array called results, that contains stdClass objects that represents an activity. It accepts two parameters - start and limit; start is the record that you wish to start from, and limit is the number of records that you would like returned.
+Returns a stdClass object, which contains an array called results, that contains stdClass objects that represents an activity. It accepts three parameters - start, limit and activity type; start is the record that you wish to start from, limit is the number of records that you would like returned, and activity type is the (optional) string representation of the activity type returned from `getActivityTypes()`
 
 #### Example
 

--- a/examples/example.php
+++ b/examples/example.php
@@ -1,4 +1,7 @@
 <?php
+
+use dawguk\GarminConnect;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $arrCredentials = array(
@@ -7,9 +10,9 @@ $arrCredentials = array(
 );
 
 try {
-    $objGarminConnect = new \dawguk\GarminConnect($arrCredentials);
+    $objGarminConnect = new GarminConnect($arrCredentials);
 
-    $objResults = $objGarminConnect->getActivityList(0, 1);
+    $objResults = $objGarminConnect->getActivityList(0, 5, 'cycling');
     print_r($objResults);
 
 } catch (Exception $objException) {

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -187,7 +187,7 @@ class GarminConnect
     public function getActivityTypes()
     {
         $strResponse = $this->objConnector->get(
-            'https://connect.garmin.com/proxy/activity-service-1.2/json/activity_types',
+            'https://connect.garmin.com/modern/proxy/activity-service/activity/activityTypes',
             null,
             false
         );
@@ -203,15 +203,20 @@ class GarminConnect
      *
      * @param integer $intStart
      * @param integer $intLimit
-     * @throws UnexpectedResponseCodeException
+     * @param null $strActivityType
      * @return mixed
+     * @throws UnexpectedResponseCodeException
      */
-    public function getActivityList($intStart = 0, $intLimit = 10)
+    public function getActivityList($intStart = 0, $intLimit = 10, $strActivityType = null)
     {
         $arrParams = array(
             'start' => $intStart,
             'limit' => $intLimit
         );
+
+        if (null !== $strActivityType) {
+            $arrParams['activityType'] = $strActivityType;
+        }
 
         $strResponse = $this->objConnector->get(
             'https://connect.garmin.com/modern/proxy/activitylist-service/activities/search/activities',

--- a/src/dawguk/GarminConnect/Connector.php
+++ b/src/dawguk/GarminConnect/Connector.php
@@ -17,6 +17,8 @@
 
 namespace dawguk\GarminConnect;
 
+use Exception;
+
 class Connector
 {
    /**
@@ -51,13 +53,13 @@ class Connector
 
    /**
     * @param string $strUniqueIdentifier
-    * @throws \Exception
+    * @throws Exception
     */
     public function __construct($strUniqueIdentifier)
     {
         $this->strCookieDirectory = sys_get_temp_dir();
         if (strlen(trim($strUniqueIdentifier)) == 0) {
-            throw new \Exception("Identifier isn't valid");
+            throw new Exception("Identifier isn't valid");
         }
         $this->strCookieFile = $this->strCookieDirectory . DIRECTORY_SEPARATOR . "GarminCookie_" . $strUniqueIdentifier;
         $this->refreshSession();
@@ -82,7 +84,7 @@ class Connector
     */
     public function get($strUrl, $arrParams = array(), $bolAllowRedirects = true)
     {
-        if (count($arrParams)) {
+        if (null !== $arrParams && count($arrParams)) {
             $strUrl .= '?' . http_build_query($arrParams);
         }
 


### PR DESCRIPTION
- getActivityTypes() had it's endpoint URL fixed, so is now working again.
- Can now call getActivityList() with an optional third parameter, which is a string representation of the activity type
that is returned in the getActivityTypes() method.