### PR TITLE
Support downloading of original .fit files

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Returns a string representation of requested data type, for the given activity I
 
 |Type | Returns |
 |---- | ------- |
+|\dawguk\GarminConnect::DATA_TYPE_FIT | Original .fit file, zipped |
 |\dawguk\GarminConnect::DATA_TYPE_GPX | GPX as XML string |
 |\dawguk\GarminConnect::DATA_TYPE_TCX | TCX as XML string |
 |\dawguk\GarminConnect::DATA_TYPE_GOOGLE_EARTH | Google Earth as XML string |

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -24,6 +24,7 @@ use Exception;
 
 class GarminConnect
 {
+    const DATA_TYPE_FIT = 'fit';
     const DATA_TYPE_TCX = 'tcx';
     const DATA_TYPE_GPX = 'gpx';
     const DATA_TYPE_GOOGLE_EARTH = 'kml';
@@ -456,13 +457,14 @@ class GarminConnect
             case self::DATA_TYPE_GPX:
             case self::DATA_TYPE_TCX:
             case self::DATA_TYPE_GOOGLE_EARTH:
+                $strUrl = "https://connect.garmin.com/modern/proxy/download-service/export/" . $strType . "/activity/" . $intActivityID;
                 break;
-
+            case self::DATA_TYPE_FIT:
+                $strUrl = "https://connect.garmin.com/modern/proxy/download-service/files/activity/" . $intActivityID;
+                break;
             default:
                 throw new Exception("Unsupported data type");
         }
-
-        $strUrl = "https://connect.garmin.com/modern/proxy/download-service/export/" . $strType . "/activity/" . $intActivityID;
 
         $strResponse = $this->objConnector->get($strUrl);
         if ($this->objConnector->getLastResponseCode() != 200) {

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -562,15 +562,14 @@ class GarminConnect
         return $objResponse;
     }
 	
-	/**
+   /**
     * Retrieves sleep data
     *
     * @throws GarminConnect\exceptions\UnexpectedResponseCodeException
     * @throws Exception
     * @return mixed
     */
-
-	public function getSleepData()
+    public function getSleepData()
     {
         $arrParams = Array();
 


### PR DESCRIPTION
For whatever reason, Connect responds with a zipped version of the file so I've made a note of this in the README.