### PR TITLE
Feat/api/filter activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The library implements a few basic API functions that you can use to retrieve us
 | Method                  | Parameters           | Returns                     |
 | ----------------------- | -------------------- | --------------------------- |
 | getActivityTypes()      | -                 | Array                    |
-| getActivityList()       | integer $intStart, integer $intLimit, string $strActivityType | stdClass    |
+| getActivityList()       | integer $intStart, integer $intLimit, string $strActivityType, array $filters | stdClass    |
 | getActivitySummary()    | integer $intActivityID | stdClass                  |
 | getActivityDetails()    | integer $intActivityID | stdClass |
 | getDataFile             | string $strType, integer $intActivityID | string |
@@ -105,7 +105,7 @@ try {
             )
 
  
-### getActivityList(integer $intStart, integer $intLimit, string $strActivityType)
+### getActivityList(integer $intStart, integer $intLimit, string $strActivityType, array $filters)
 
 Returns a stdClass object, which contains an array called results, that contains stdClass objects that represents an activity. It accepts three parameters - start, limit and activity type; start is the record that you wish to start from, limit is the number of records that you would like returned, and activity type is the (optional) string representation of the activity type returned from `getActivityTypes()`
 

--- a/src/dawguk/GarminConnect.php
+++ b/src/dawguk/GarminConnect.php
@@ -205,10 +205,11 @@ class GarminConnect
      * @param integer $intStart
      * @param integer $intLimit
      * @param null $strActivityType
+     * @param array $filters
      * @return mixed
      * @throws UnexpectedResponseCodeException
      */
-    public function getActivityList($intStart = 0, $intLimit = 10, $strActivityType = null)
+    public function getActivityList($intStart = 0, $intLimit = 10, $strActivityType = null, $filters = array())
     {
         $arrParams = array(
             'start' => $intStart,
@@ -217,6 +218,10 @@ class GarminConnect
 
         if (null !== $strActivityType) {
             $arrParams['activityType'] = $strActivityType;
+        }
+
+        if (!empty($filters)) {
+            $arrParams = array_merge($arrParams, $filters);
         }
 
         $strResponse = $this->objConnector->get(


### PR DESCRIPTION
Hello @dawguk,

Thanks for your great library, it helped me a lot to build some [useful analytics](http://run.bientz.com/).

This PR allows to pass additional filters to the `getActivityList`() method because I needed to search for specific distances, between dates, sort by a column, [...], it's possible on Garmin Connect:

![image](https://user-images.githubusercontent.com/6093572/129333189-2450e43c-4058-47a5-9f04-1db77ccb85af.png)

Rather than adding X new parameters to your method, I just decided to add an optional array and merging it with the existing params:

```php
public function getActivityList($intStart = 0, $intLimit = 10, $strActivityType = null, $filters = array())
```

Full example:
```php
$response = $client->getActivityList(0, 1, 'running', [
	'minDistance' => 4902,
	'maxDistance' => 5100,
	'startDate' => '2021-01-01',
	'endDate' => '2021-08-13',
	'sortBy' => 'elapsedDuration',
	'sortOrder' => 'asc',
]);
```

Note that `getActivityList($filters = array())` would have been enough (because we can define `start`, `limit` & `activityType` in the same array) but to preserve backward compatibility, I decided to let the legacy params even if we can override them in that array.